### PR TITLE
Add check to ensure we are not creating issues for PRs

### DIFF
--- a/sync2jira/main.py
+++ b/sync2jira/main.py
@@ -137,7 +137,7 @@ def handle_message(config, incoming_json):
             pr = u_pr.handle_github_message(config, incoming_json)
             if pr:
                 d_pr.sync_with_jira(pr, config)
-        elif ('issue' in incoming_json.keys()):
+        elif ('issue' in incoming_json.keys() and '/pull/' not in incoming_json['issue']['html_url']):
             issue = u_issue.handle_github_message(config, incoming_json)
             if issue:
                 d_issue.sync_with_jira(issue, config)


### PR DESCRIPTION
This PR fixes the issue where pr comments would create issues. We just ensure that we are not looking at a PR when dispatching to the issue handler. 